### PR TITLE
npm publish 時にエラーnpm error 400

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "download-font-webpack-plugin",
+  "name": "@nojaja/download-font-webpack-plugin",
   "version": "1.0.0",
   "description": "Webpack plugin to download and bundle web fonts.",
   "main": "dist/download-font-plugin.js",


### PR DESCRIPTION
npm publish 時に「That word is not allowed.」というエラー（npm error 400 Bad Request）が発生したのでpackage名を変更